### PR TITLE
Added support for limits in lighting calculations.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "bsru"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 dependencies = [
  "bevy_color",
  "bevy_reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsru"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 edition = "2024"
 description = "Beatsaber Rust Utilities: A Beatsaber V3 parsing library."
 categories = ["game-development", "data-structures", "parser-implementations"]

--- a/src/difficulty/lightshow.rs
+++ b/src/difficulty/lightshow.rs
@@ -25,7 +25,7 @@ loose_enum! {
 }
 
 impl DistributionType {
-    #[deprecated(note = "Experimental. Does not consider random or limit in filter calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in filter calculations.")]
     #[allow(deprecated)]
     fn compute_beat_offset(
         &self,
@@ -55,7 +55,7 @@ impl DistributionType {
         )
     }
 
-    #[deprecated(note = "Experimental. Does not consider random or limit in filter calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in filter calculations.")]
     #[allow(deprecated)]
     fn compute_value_offset(
         &self,
@@ -85,7 +85,7 @@ impl DistributionType {
         )
     }
 
-    #[deprecated(note = "Experimental. Does not consider random or limit in filter calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in filter calculations.")]
     #[allow(deprecated)]
     #[inline(always)]
     fn compute_offset(

--- a/src/difficulty/lightshow.rs
+++ b/src/difficulty/lightshow.rs
@@ -39,7 +39,7 @@ impl DistributionType {
         let filtered_id = filter.get_relative_index(light_id, group_size);
 
         let filtered_size = if let Some(limit_behaviour) = filter.limit_behaviour
-            && limit_behaviour.duration()
+            && limit_behaviour.beat_enabled()
         {
             filter.count_filtered(group_size)
         } else {
@@ -69,7 +69,7 @@ impl DistributionType {
         let filtered_id = filter.get_relative_index(light_id, group_size);
 
         let filtered_size = if let Some(limit_behaviour) = filter.limit_behaviour
-            && limit_behaviour.distribution()
+            && limit_behaviour.value_enabled()
         {
             filter.count_filtered(group_size)
         } else {

--- a/src/difficulty/lightshow/filter.rs
+++ b/src/difficulty/lightshow/filter.rs
@@ -229,25 +229,30 @@ loose_enum!(
 );
 
 loose_enum!(
+    /// Controls whether to extend wave distributions so they match the duration before the limit was applied.
+    ///
+    /// To see this in practice, check out [this video](https://youtube.com/watch?v=NJPPBvyHJjg&t=338).
+    ///
+    /// Includes the option to only enable for beat distribution and not value distribution, and vice versa.
     #[derive(Default, Copy)]
     LimitBehaviour: i32 {
         #[default]
         None = 0,
-        Duration = 1,
-        Distribution = 2,
+        Beat = 1,
+        Value = 2,
         Both = 3,
     }
 );
 
 impl LimitBehaviour {
-    /// Returns true if duration limiting is enabled, that is either `Duration` or `Both`.
+    /// Returns true if duration limiting is enabled, that is either `Beat` or `Both`.
     pub fn duration(&self) -> bool {
-        matches!(self, LimitBehaviour::Duration | LimitBehaviour::Both)
+        matches!(self, LimitBehaviour::Beat | LimitBehaviour::Both)
     }
 
-    /// Returns true if distribution limiting is enabled, that is either `Distribution` or `Both`.
+    /// Returns true if distribution limiting is enabled, that is either `Value` or `Both`.
     pub fn distribution(&self) -> bool {
-        matches!(self, LimitBehaviour::Distribution | LimitBehaviour::Both)
+        matches!(self, LimitBehaviour::Value | LimitBehaviour::Both)
     }
 }
 

--- a/src/difficulty/lightshow/filter.rs
+++ b/src/difficulty/lightshow/filter.rs
@@ -245,13 +245,13 @@ loose_enum!(
 );
 
 impl LimitBehaviour {
-    /// Returns true if duration limiting is enabled, that is either `Beat` or `Both`.
-    pub fn duration(&self) -> bool {
+    /// Returns true if beat limiting is enabled, that is either `Beat` or `Both`.
+    pub fn beat_enabled(&self) -> bool {
         matches!(self, LimitBehaviour::Beat | LimitBehaviour::Both)
     }
 
-    /// Returns true if distribution limiting is enabled, that is either `Value` or `Both`.
-    pub fn distribution(&self) -> bool {
+    /// Returns true if value limiting is enabled, that is either `Value` or `Both`.
+    pub fn value_enabled(&self) -> bool {
         matches!(self, LimitBehaviour::Value | LimitBehaviour::Both)
     }
 }
@@ -526,7 +526,7 @@ mod tests {
     #[test]
     fn limit_non_factor_all_but_one() {
         let filter = Filter {
-            limit_percent: Some(0.90),
+            limit_percent: Some(0.9),
             ..Default::default()
         };
 

--- a/src/difficulty/lightshow/filter.rs
+++ b/src/difficulty/lightshow/filter.rs
@@ -225,6 +225,18 @@ loose_enum!(
     }
 );
 
+impl LimitBehaviour {
+    /// Returns true if duration limiting is enabled, that is either `Duration` or `Both`.
+    pub fn duration(&self) -> bool {
+        matches!(self, LimitBehaviour::Duration | LimitBehaviour::Both)
+    }
+
+    /// Returns true if distribution limiting is enabled, that is either `Distribution` or `Both`.
+    pub fn distribution(&self) -> bool {
+        matches!(self, LimitBehaviour::Distribution | LimitBehaviour::Both)
+    }
+}
+
 #[allow(deprecated)]
 #[cfg(test)]
 mod tests {

--- a/src/difficulty/lightshow/filter.rs
+++ b/src/difficulty/lightshow/filter.rs
@@ -82,10 +82,11 @@ impl Filter {
     pub fn is_in_filter(&self, mut light_id: i32, mut group_size: i32) -> bool {
         assert!(light_id < group_size);
 
-        if let Some(limit) = self.limit_percent {
-            if light_id >= (group_size as f32 * limit) as i32 {
-                return false;
-            }
+        if let Some(limit) = self.limit_percent
+            && limit > 0.0
+            && light_id >= (group_size as f32 * limit) as i32
+        {
+            return false;
         }
 
         if self.reverse.is_true() {

--- a/src/difficulty/lightshow/filter.rs
+++ b/src/difficulty/lightshow/filter.rs
@@ -78,7 +78,7 @@ impl Filter {
     /// Will panic if the light ID is greater than or equal to the group size.
     #[must_use]
     #[inline]
-    #[deprecated(note = "Experimental. Does not consider random or limit in calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in calculations.")]
     pub fn is_in_filter(&self, mut light_id: i32, mut group_size: i32) -> bool {
         assert!(light_id < group_size);
 
@@ -122,7 +122,7 @@ impl Filter {
     /// If the [`FilterType`] is `Unknown` then the result will be the same as `group_size`.
     #[must_use]
     #[inline]
-    #[deprecated(note = "Experimental. Does not consider random or limit in calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in calculations.")]
     pub(crate) fn count_filtered_without_limit(&self, mut group_size: i32) -> i32 {
         if let Some(chunks) = self.chunks
             && chunks > 0
@@ -149,7 +149,7 @@ impl Filter {
     /// If the [`FilterType`] is `Unknown` then the result will be the same as `group_size`.
     #[must_use]
     #[inline]
-    #[deprecated(note = "Experimental. Does not consider random or limit in calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in calculations.")]
     #[allow(deprecated)]
     pub fn count_filtered(&self, group_size: i32) -> i32 {
         let filtered = self.count_filtered_without_limit(group_size);
@@ -170,7 +170,7 @@ impl Filter {
     // Todo what is the behaviour when the light ID is not in the filter?
     #[must_use]
     #[inline]
-    #[deprecated(note = "Experimental. Does not consider random or limit in calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in calculations.")]
     pub fn get_relative_index(&self, mut light_id: i32, mut group_size: i32) -> i32 {
         assert!(light_id < group_size);
 

--- a/src/difficulty/lightshow/group.rs
+++ b/src/difficulty/lightshow/group.rs
@@ -71,7 +71,7 @@ macro_rules! impl_event_group {
 
             #[allow(deprecated)]
             fn get_beat_offset(&self, light_id: i32, group_size: i32) -> f32 {
-                self.beat_dist_type.compute_offset(
+                self.beat_dist_type.compute_beat_offset(
                     light_id,
                     group_size,
                     &self.filter,

--- a/src/difficulty/lightshow/group.rs
+++ b/src/difficulty/lightshow/group.rs
@@ -44,13 +44,13 @@ pub trait EventGroup {
     /// Returns the number of beats that the event will be offset for a given light ID.
     /// # Panics
     /// Will panic if the light ID is greater than or equal to the group size.
-    #[deprecated(note = "Experimental. Does not consider random or limit in filter calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in filter calculations.")]
     fn get_beat_offset(&self, light_id: i32, group_size: i32) -> f32;
 
     /// Returns the value (i.e. brightness) that the event will be offset for a given light ID.
     /// # Panics
     /// Will panic if the light ID is greater than or equal to the group size.
-    #[deprecated(note = "Experimental. Does not consider random or limit in filter calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in filter calculations.")]
     fn get_value_offset(&self, light_id: i32, group_size: i32) -> f32;
 }
 

--- a/src/difficulty/lightshow/group/color.rs
+++ b/src/difficulty/lightshow/group/color.rs
@@ -93,7 +93,7 @@ impl ColorEventGroup {
     /// Returns the brightness that the event will be offset for a given light ID.
     /// # Panics
     /// Will panic if the light ID is greater than or equal to the group size.
-    #[deprecated(note = "Experimental. Does not consider random or limit in filter calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in filter calculations.")]
     #[allow(deprecated)]
     pub fn get_brightness_offset(&self, light_id: i32, group_size: i32) -> f32 {
         self.bright_dist_type.compute_value_offset(

--- a/src/difficulty/lightshow/group/color.rs
+++ b/src/difficulty/lightshow/group/color.rs
@@ -415,7 +415,7 @@ mod tests {
     fn beat_wave_with_limit_filter() {
         let group = ColorEventGroup {
             filter: Filter {
-                limit_behaviour: Some(LimitBehaviour::Duration),
+                limit_behaviour: Some(LimitBehaviour::Beat),
                 limit_percent: Some(0.5),
                 ..Default::default()
             },
@@ -431,7 +431,7 @@ mod tests {
     fn brightness_wave_with_limit_filter() {
         let group = ColorEventGroup {
             filter: Filter {
-                limit_behaviour: Some(LimitBehaviour::Distribution),
+                limit_behaviour: Some(LimitBehaviour::Value),
                 limit_percent: Some(0.5),
                 ..Default::default()
             },

--- a/src/difficulty/lightshow/group/color.rs
+++ b/src/difficulty/lightshow/group/color.rs
@@ -96,7 +96,7 @@ impl ColorEventGroup {
     #[deprecated(note = "Experimental. Does not consider random or limit in filter calculations.")]
     #[allow(deprecated)]
     pub fn get_brightness_offset(&self, light_id: i32, group_size: i32) -> f32 {
-        self.bright_dist_type.compute_offset(
+        self.bright_dist_type.compute_value_offset(
             light_id,
             group_size,
             &self.filter,
@@ -189,6 +189,7 @@ loose_enum! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::LimitBehaviour;
     use crate::difficulty::lightshow::filter::FilterType;
     use crate::difficulty::lightshow::group::EventGroup;
 
@@ -408,5 +409,37 @@ mod tests {
         };
 
         assert!((0..12).all(|i| group.get_brightness_offset(i, 12) == 12.0 - i as f32));
+    }
+
+    #[test]
+    fn beat_wave_with_limit_filter() {
+        let group = ColorEventGroup {
+            filter: Filter {
+                limit_behaviour: Some(LimitBehaviour::Duration),
+                limit_percent: Some(0.5),
+                ..Default::default()
+            },
+            beat_dist_type: DistributionType::Wave,
+            beat_dist_value: 12.0,
+            ..Default::default()
+        };
+
+        assert!((0..6).all(|i| group.get_beat_offset(i, 12) == (i * 2) as f32));
+    }
+
+    #[test]
+    fn brightness_wave_with_limit_filter() {
+        let group = ColorEventGroup {
+            filter: Filter {
+                limit_behaviour: Some(LimitBehaviour::Distribution),
+                limit_percent: Some(0.5),
+                ..Default::default()
+            },
+            bright_dist_type: DistributionType::Wave,
+            bright_dist_value: 12.0,
+            ..Default::default()
+        };
+
+        assert!((0..6).all(|i| group.get_brightness_offset(i, 12) == (i * 2) as f32));
     }
 }

--- a/src/difficulty/lightshow/group/rotation.rs
+++ b/src/difficulty/lightshow/group/rotation.rs
@@ -101,7 +101,7 @@ impl RotationEventGroup {
     /// Returns the number of degrees that the event will be offset for a given light ID.
     /// # Panics
     /// Will panic if the light ID is greater than or equal to the group size.
-    #[deprecated(note = "Experimental. Does not consider random or limit in filter calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in filter calculations.")]
     #[allow(deprecated)]
     pub fn get_rotation_offset(&self, light_id: i32, group_size: i32) -> f32 {
         self.rotation_dist_type.compute_value_offset(

--- a/src/difficulty/lightshow/group/rotation.rs
+++ b/src/difficulty/lightshow/group/rotation.rs
@@ -104,7 +104,7 @@ impl RotationEventGroup {
     #[deprecated(note = "Experimental. Does not consider random or limit in filter calculations.")]
     #[allow(deprecated)]
     pub fn get_rotation_offset(&self, light_id: i32, group_size: i32) -> f32 {
-        self.rotation_dist_type.compute_offset(
+        self.rotation_dist_type.compute_value_offset(
             light_id,
             group_size,
             &self.filter,

--- a/src/difficulty/lightshow/group/translation.rs
+++ b/src/difficulty/lightshow/group/translation.rs
@@ -110,7 +110,7 @@ impl TranslationEventGroup {
     #[deprecated(note = "Experimental. Does not consider random or limit in filter calculations.")]
     #[allow(deprecated)]
     pub fn get_translation_offset(&self, light_id: i32, group_size: i32) -> f32 {
-        self.translation_dist_type.compute_offset(
+        self.translation_dist_type.compute_value_offset(
             light_id,
             group_size,
             &self.filter,

--- a/src/difficulty/lightshow/group/translation.rs
+++ b/src/difficulty/lightshow/group/translation.rs
@@ -107,7 +107,7 @@ impl TranslationEventGroup {
     /// Returns the number of units that the event will be offset for a given light ID.
     /// # Panics
     /// Will panic if the light ID is greater than or equal to the group size.
-    #[deprecated(note = "Experimental. Does not consider random or limit in filter calculations.")]
+    #[deprecated(note = "Experimental. Does not consider random in filter calculations.")]
     #[allow(deprecated)]
     pub fn get_translation_offset(&self, light_id: i32, group_size: i32) -> f32 {
         self.translation_dist_type.compute_value_offset(

--- a/test_maps/README.md
+++ b/test_maps/README.md
@@ -1,1 +1,6 @@
 Put testing maps in this directory.
+
+The map test is ignored by default, so to run it use:
+```rust
+cargo test -- --ignored
+```

--- a/tests/parse_map.rs
+++ b/tests/parse_map.rs
@@ -3,6 +3,7 @@ use bsru::info::Beatmap;
 use std::fs;
 
 #[test]
+#[ignore]
 fn parse_beatmaps() {
     let paths = fs::read_dir("test_maps").unwrap().filter_map(|result| {
         if let Ok(dir) = result {


### PR DESCRIPTION
Fixes #4.

Also renames `LimitBehaviour`'s cases to match the terminology in the rest of the project.
- `Duration`  -> `Beat`
- `Distribution` -> `Value`