### PR TITLE
Hide re-exports from docs.

### DIFF
--- a/src/difficulty.rs
+++ b/src/difficulty.rs
@@ -4,8 +4,11 @@ pub mod gameplay_event;
 pub mod lightshow;
 pub mod playfield;
 
+#[doc(hidden)]
 pub use gameplay_event::*;
+#[doc(hidden)]
 pub use lightshow::*;
+#[doc(hidden)]
 pub use playfield::*;
 
 use serde::{Deserialize, Serialize};

--- a/src/difficulty/lightshow.rs
+++ b/src/difficulty/lightshow.rs
@@ -5,9 +5,13 @@ pub mod easing;
 pub mod filter;
 pub mod group;
 
+#[doc(hidden)]
 pub use basic::*;
+#[doc(hidden)]
 pub use easing::*;
+#[doc(hidden)]
 pub use filter::*;
+#[doc(hidden)]
 pub use group::*;
 
 use crate::loose_enum;

--- a/src/difficulty/lightshow/group.rs
+++ b/src/difficulty/lightshow/group.rs
@@ -4,8 +4,11 @@ pub mod color;
 pub mod rotation;
 pub mod translation;
 
+#[doc(hidden)]
 pub use color::*;
+#[doc(hidden)]
 pub use rotation::*;
+#[doc(hidden)]
 pub use translation::*;
 
 use crate::difficulty::lightshow::filter::Filter;

--- a/src/info.rs
+++ b/src/info.rs
@@ -2,6 +2,7 @@
 
 pub mod color_scheme;
 
+#[doc(hidden)]
 pub use color_scheme::*;
 
 use crate::loose_enum;

--- a/src/info/color_scheme.rs
+++ b/src/info/color_scheme.rs
@@ -3,6 +3,7 @@
 pub mod presets;
 
 #[allow(unused_imports)]
+#[doc(hidden)]
 pub use presets::*;
 
 use serde::{Deserialize, Serialize};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,14 @@
 pub mod difficulty;
 pub mod info;
 pub mod timing_traits;
-pub mod utils;
 
+mod utils;
+
+#[doc(hidden)]
 pub use difficulty::*;
+#[doc(hidden)]
 pub use info::*;
+#[doc(hidden)]
 pub use timing_traits::*;
+/// An integer repr bool, with 0 being false and 1 being true. Any other value will be saved as `Unknown`.
 pub use utils::LooseBool;


### PR DESCRIPTION
Also make `utils` module private.